### PR TITLE
ignore sRGB in png files since gamma is assumed to be 2.2 otherwise

### DIFF
--- a/ShaderGlass/CaptureManager.cpp
+++ b/ShaderGlass/CaptureManager.cpp
@@ -75,7 +75,10 @@ void CaptureManager::StartSession()
     {
         winrt::com_ptr<ID3D11Texture2D>          inputTexture;
         winrt::com_ptr<ID3D11ShaderResourceView> inputTextureView;
-        auto hr = DirectX::CreateWICTextureFromFile(m_d3dDevice.get(), m_options.imageFile.c_str(), (ID3D11Resource**)(inputTexture.put()), inputTextureView.put());
+        auto hr = DirectX::CreateWICTextureFromFileEx(m_d3dDevice.get(), m_options.imageFile.c_str(),
+            0, D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
+            DirectX::WIC_LOADER_IGNORE_SRGB, // "If the sRGB chunk is found, it is assumed to be gamma 2.2"
+            (ID3D11Resource**)(inputTexture.put()), inputTextureView.put());
         assert(SUCCEEDED(hr));
 
         // retrieve input image size


### PR DESCRIPTION
all my png files are darker without this fix, reason is "gAMA chunks in PNGs are ignored. If the sRGB chunk is found, it is assumed to be gamma 2.2"

see : 
https://github.com/microsoft/DirectXTK/wiki/WICTextureLoader

and others struggling with that issue : 
https://stackoverflow.com/questions/39634189/load-texture-as-rgb-not-srgb-in-directx11-using-wic#comment66623886_39644302