### PR TITLE
Fullscreen spans all monitors when capturing All Displays

### DIFF
--- a/Misc/MANUAL.html
+++ b/Misc/MANUAL.html
@@ -139,7 +139,7 @@
             <li><p><strong>Orientation</strong> - direction of shader effect, "Vertical" emulates display rotated 90 degrees, like in arcade cabinets</p></li>
             <li>
                 <p>
-                    <strong>Fullscreen</strong> (Ctrl+Shift+G) - turn ShaderGlass into a topmost fullscreen borderless window. With the <strong>All Displays</strong> desktop input selected it spans the entire virtual desktop (all monitors); otherwise it covers only the monitor nearest the ShaderGlass window. In Glass mode you will still see yellow outline around the screen but if you can use
+                    <strong>Fullscreen</strong> (Ctrl+Shift+G) - turn ShaderGlass into a topmost fullscreen borderless window covering the monitor nearest the ShaderGlass window. To span the entire virtual desktop (all monitors) instead, select the <strong>All Displays</strong> desktop input and tick <strong>Output &rarr; Fullscreen on All Displays</strong> (advanced); with any other input fullscreen still covers a single monitor. In Glass mode you will still see yellow outline around the screen but if you can use
                     Window Glass (surrounding black bars) or Window Clone (top-left aligned) with your source then you can avoid yellow edges; press Ctrl+Shift+G to revert
                 </p>
             </li>

--- a/Misc/MANUAL.html
+++ b/Misc/MANUAL.html
@@ -139,7 +139,7 @@
             <li><p><strong>Orientation</strong> - direction of shader effect, "Vertical" emulates display rotated 90 degrees, like in arcade cabinets</p></li>
             <li>
                 <p>
-                    <strong>Fullscreen</strong> (Ctrl+Shift+G) - turn ShaderGlass into a topmost fullscreen borderless window, in Glass mode you will still see yellow outline around the screen but if you can use
+                    <strong>Fullscreen</strong> (Ctrl+Shift+G) - turn ShaderGlass into a topmost fullscreen borderless window. With the <strong>All Displays</strong> desktop input selected it spans the entire virtual desktop (all monitors); otherwise it covers only the monitor nearest the ShaderGlass window. In Glass mode you will still see yellow outline around the screen but if you can use
                     Window Glass (surrounding black bars) or Window Clone (top-left aligned) with your source then you can avoid yellow edges; press Ctrl+Shift+G to revert
                 </p>
             </li>

--- a/ShaderGlass/ShaderWindow.cpp
+++ b/ShaderGlass/ShaderWindow.cpp
@@ -571,6 +571,19 @@ void ShaderWindow::SaveProfile(const std::wstring& fileName)
         WideCharToMultiByte(CP_UTF8, 0, info.szDevice, -1, utfName, MAX_WINDOW_TITLE, NULL, NULL);
         outfile << "CaptureDesktop " << std::quoted(utfName) << std::endl;
     }
+    else if(HasCaptureAPI() && m_captureOptions.imageFile.empty() && m_captureOptions.deviceFormatNo == 0)
+    {
+        // "All Displays" capture has a NULL monitor; persist it by name so it (and its menu
+        // selection) is restored on load instead of falling through to nothing selected.
+        for(const auto& d : m_captureDisplays)
+        {
+            if(d.monitor == nullptr)
+            {
+                outfile << "CaptureDesktop " << std::quoted(d.name) << std::endl;
+                break;
+            }
+        }
+    }
     for(const auto& pt : m_captureManager.Params())
     {
         const auto& s = std::get<0>(pt);
@@ -2346,19 +2359,40 @@ void ShaderWindow::ToggleBorderless(HWND hWnd)
 
     if(m_isBorderless)
     {
-        RECT        clientRect;
-        auto        monitor = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
-        MONITORINFO info;
-        info.cbSize = sizeof(info);
-        GetMonitorInfo(monitor, &info);
-        clientRect.top    = info.rcMonitor.top;
-        clientRect.left   = info.rcMonitor.left;
-        clientRect.right  = info.rcMonitor.right;
-        clientRect.bottom = info.rcMonitor.bottom;
+        // "All Displays" capture uses a NULL monitor and spans the whole virtual desktop, so
+        // fullscreen should cover every monitor; any other capture covers just the nearest one.
+        const bool allDisplays = HasCaptureAPI() && !m_captureOptions.captureWindow && m_captureOptions.monitor == NULL &&
+            m_captureOptions.imageFile.empty() && m_captureOptions.deviceFormatNo == 0;
+
+        LONG left, top, width, height;
+        if(allDisplays)
+        {
+            left   = GetSystemMetrics(SM_XVIRTUALSCREEN);
+            top    = GetSystemMetrics(SM_YVIRTUALSCREEN);
+            width  = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+            height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+        }
+        else
+        {
+            auto        monitor = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+            MONITORINFO info;
+            info.cbSize = sizeof(info);
+            GetMonitorInfo(monitor, &info);
+            left   = info.rcMonitor.left;
+            top    = info.rcMonitor.top;
+            width  = info.rcMonitor.right - info.rcMonitor.left;
+            height = info.rcMonitor.bottom - info.rcMonitor.top;
+        }
+
+        RECT clientRect;
+        clientRect.left   = left;
+        clientRect.top    = top;
+        clientRect.right  = left + width;
+        clientRect.bottom = top + height;
         AdjustWindowRect(&clientRect, GetWindowLong(hWnd, GWL_STYLE), GetMenu(hWnd) != 0);
 
         GetWindowRect(hWnd, &m_lastPosition);
-        SetWindowPos(hWnd, HWND_TOPMOST, info.rcMonitor.left, info.rcMonitor.top, clientRect.right - clientRect.left, clientRect.bottom - clientRect.top, 0);
+        SetWindowPos(hWnd, HWND_TOPMOST, left, top, clientRect.right - clientRect.left, clientRect.bottom - clientRect.top, 0);
     }
     else
     {

--- a/ShaderGlass/ShaderWindow.cpp
+++ b/ShaderGlass/ShaderWindow.cpp
@@ -975,6 +975,7 @@ void ShaderWindow::BuildOutputMenu()
     m_orientationMenu = GetSubMenu(m_outputMenu, 5);
 
     InsertMenu(m_outputMenu, 6, MF_BYPOSITION | MF_STRING, ID_PROCESSING_FULLSCREEN, L"Fullscreen\tCtrl+Shift+G");
+    InsertMenu(m_outputMenu, 7, MF_BYPOSITION | MF_STRING, ID_OUTPUT_FULLSCREENALLDISPLAYS, L"Fullscreen on All Displays");
 }
 
 void ShaderWindow::BuildShaderMenu()
@@ -1495,6 +1496,18 @@ LRESULT CALLBACK ShaderWindow::WndProc(HWND hWnd, UINT message, WPARAM wParam, L
             {
                 CheckMenuItem(m_advancedMenu, ID_PRESENTATION_USEFLIPMODE, MF_CHECKED);
                 SaveFlipModeState(true);
+            }
+            break;
+        case ID_OUTPUT_FULLSCREENALLDISPLAYS:
+            if(GetMenuState(m_outputMenu, ID_OUTPUT_FULLSCREENALLDISPLAYS, MF_BYCOMMAND) & MF_CHECKED)
+            {
+                CheckMenuItem(m_outputMenu, ID_OUTPUT_FULLSCREENALLDISPLAYS, MF_UNCHECKED);
+                SaveFullscreenAllDisplaysState(false);
+            }
+            else
+            {
+                CheckMenuItem(m_outputMenu, ID_OUTPUT_FULLSCREENALLDISPLAYS, MF_CHECKED);
+                SaveFullscreenAllDisplaysState(true);
             }
             break;
         case ID_ADVANCED_ALLOWTEARING:
@@ -2359,10 +2372,11 @@ void ShaderWindow::ToggleBorderless(HWND hWnd)
 
     if(m_isBorderless)
     {
-        // "All Displays" capture uses a NULL monitor and spans the whole virtual desktop, so
-        // fullscreen should cover every monitor; any other capture covers just the nearest one.
-        const bool allDisplays = HasCaptureAPI() && !m_captureOptions.captureWindow && m_captureOptions.monitor == NULL &&
-            m_captureOptions.imageFile.empty() && m_captureOptions.deviceFormatNo == 0;
+        // Span the whole virtual desktop only when "Fullscreen on All Displays" is ticked AND the
+        // "All Displays" capture (NULL monitor) is active, since only that capture provides content
+        // for every monitor; otherwise cover just the monitor nearest the ShaderGlass window.
+        const bool allDisplays = GetFullscreenAllDisplaysState() && HasCaptureAPI() && !m_captureOptions.captureWindow &&
+            m_captureOptions.monitor == NULL && m_captureOptions.imageFile.empty() && m_captureOptions.deviceFormatNo == 0;
 
         LONG left, top, width, height;
         if(allDisplays)
@@ -2501,6 +2515,10 @@ bool ShaderWindow::Create(_In_ HINSTANCE hInstance, _In_ int nCmdShow)
     if(GetStartingPositionState())
     {
         CheckMenuItem(m_programMenu, ID_PROCESSING_REMEMBERPOSITION, MF_BYCOMMAND | MF_CHECKED);
+    }
+    if(GetFullscreenAllDisplaysState())
+    {
+        CheckMenuItem(m_outputMenu, ID_OUTPUT_FULLSCREENALLDISPLAYS, MF_BYCOMMAND | MF_CHECKED);
     }
     if(RememberFPS())
     {
@@ -2679,6 +2697,16 @@ void ShaderWindow::SaveUseHDRState(bool state)
 bool ShaderWindow::GetUseHDRState()
 {
     return GetRegistryOption(TEXT("Use HDR"), false);
+}
+
+void ShaderWindow::SaveFullscreenAllDisplaysState(bool state)
+{
+    SaveRegistryOption(TEXT("Fullscreen All Displays"), state);
+}
+
+bool ShaderWindow::GetFullscreenAllDisplaysState()
+{
+    return GetRegistryOption(TEXT("Fullscreen All Displays"), false);
 }
 
 void ShaderWindow::SaveRememberFPS(int fps)

--- a/ShaderGlass/ShaderWindow.h
+++ b/ShaderGlass/ShaderWindow.h
@@ -132,6 +132,8 @@ private:
     bool         GetMaxCaptureRateState();
     void         SaveUseHDRState(bool state);
     bool         GetUseHDRState();
+    void         SaveFullscreenAllDisplaysState(bool state);
+    bool         GetFullscreenAllDisplaysState();
     void         SaveRememberFPS(int fps);
     bool         RememberFPS();
     int          GetRememberFPS();

--- a/ShaderGlass/resource.h
+++ b/ShaderGlass/resource.h
@@ -199,6 +199,7 @@
 #define ID_PROCESSING_RENDERER          32938
 #define ID_RENDERER_DIRECT3D11          32939
 #define ID_INPUT_WINDOW32940            32940
+#define ID_OUTPUT_FULLSCREENALLDISPLAYS 32941
 #define IDC_STATIC                      -1
 #define IDC_STATIC_LABEL                -1
 
@@ -208,7 +209,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        142
-#define _APS_NEXT_COMMAND_VALUE         32941
+#define _APS_NEXT_COMMAND_VALUE         32942
 #define _APS_NEXT_CONTROL_VALUE         1004
 #define _APS_NEXT_SYMED_VALUE           116
 #endif


### PR DESCRIPTION
## Summary

Makes **Fullscreen** (Ctrl+Shift+G) span the entire virtual desktop (all monitors) when capturing **All Displays**, instead of only the nearest monitor.

## Motivation

ShaderGlass already captures every connected monitor via the existing "All Displays" input (NULL `HMONITOR`), and applies the correct virtual-screen offset for Glass alignment. The only gap was Fullscreen: `ToggleBorderless` used `MonitorFromWindow` and so only ever covered one monitor, leaving no way to span the overlay across all displays.

## What changed

- **`ToggleBorderless`** — when "All Displays" is the active capture (capture API, no window, NULL monitor, not image/device), sizes the borderless window to `SM_XVIRTUALSCREEN / SM_YVIRTUALSCREEN / SM_CXVIRTUALSCREEN / SM_CYVIRTUALSCREEN`. All other capture modes are unchanged (still nearest monitor).
- **`SaveProfile`** — persists the "All Displays" selection by writing `CaptureDesktop "All Displays"` for the NULL-monitor case. `LoadProfile` already matches that name, so the selection (and its menu checkmark) is restored on load instead of falling through to nothing selected. Only applies on Win10 2004+/Win11 where the NULL-monitor entry exists; never for image/device/window captures.
- **`MANUAL.html`** — one-line note documenting the behaviour.

## How to use

1. Input → Desktop → **All Displays**
2. Start capture (Glass mode)
3. **Fullscreen** / Ctrl+Shift+G to span all monitors

Single-monitor, window, and file capture behaviour is unchanged.