### PR TITLE
fix of infinite "Compiling shader" when using two custom shader instances

### DIFF
--- a/ShaderGlass/CaptureManager.cpp
+++ b/ShaderGlass/CaptureManager.cpp
@@ -28,7 +28,7 @@ bool CaptureManager::Initialize()
 {
     m_presetList.push_back(make_unique<PassthroughPresetDef>());
     m_presetList.insert(m_presetList.end(), RetroArchPresetList.begin(), RetroArchPresetList.end());
-    m_frameEvent = CreateEvent(NULL, FALSE, FALSE, L"FrameEvent");
+    m_frameEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
     return false;
 }
 

--- a/ShaderGlass/ShaderWindow.cpp
+++ b/ShaderGlass/ShaderWindow.cpp
@@ -694,7 +694,7 @@ bool ShaderWindow::ImportShader(const std::wstring& fileName, bool forceStart)
         EnableWindow(m_mainWindow, false);
         if(!m_compileEvent)
         {
-            m_compileEvent = CreateEvent(NULL, TRUE, FALSE, TEXT("CompileEvent"));
+            m_compileEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
         }
         if(!m_compileThread)
         {


### PR DESCRIPTION
When an instance is launched with a custom shader and another instance with a custom shader is started, the program displays "Compiling shader" indefinitely, waiting for a Win32 event unlock. This happens because the program creates the events as named events, which are shared across processes in the session. `CompileEvent` itself is a manual reset event, so the first instance's idle shader compile thread wakes on the second instance's `SetEvent`, calls `ResetEvent`, and consumes the signal before the second instance's worker reaches its wait. `FrameEvent` exhibited the same issue, so the fix applies to it as well.

This PR makes both of the events NULL-named, which fixes the issue.